### PR TITLE
Need to add classname to prototype for GWT compatibility #3

### DIFF
--- a/pathseg.js
+++ b/pathseg.js
@@ -14,6 +14,8 @@
             this._owningPathSegList = owningPathSegList;
         }
 
+        SVGPathSeg.prototype.classname = "SVGPathSeg";
+
         SVGPathSeg.PATHSEG_UNKNOWN = 0;
         SVGPathSeg.PATHSEG_CLOSEPATH = 1;
         SVGPathSeg.PATHSEG_MOVETO_ABS = 2;
@@ -343,6 +345,8 @@
             this._pathElementMutationObserver = new MutationObserver(this._updateListFromPathMutations.bind(this));
             this._pathElementMutationObserver.observe(this._pathElement, this._mutationObserverConfig);
         }
+
+        SVGPathSegList.prototype.classname = "SVGPathSegList";
 
         Object.defineProperty(SVGPathSegList.prototype, "numberOfItems", {
             get: function() {


### PR DESCRIPTION
Extended SVGPathSeg and SVGPathSegList prototypes with 'classname' property that is required by lib-gvt-svg library to work properly with this polyfill

https://code.google.com/p/chromium/issues/detail?id=539385#c65

