### PR TITLE
Implement and test path.getPathSegAtLength polyfill

### DIFF
--- a/pathseg.js
+++ b/pathseg.js
@@ -332,6 +332,31 @@
         window.SVGPathElement.prototype.createSVGPathSegCurvetoCubicSmoothRel = function(x, y, x2, y2) { return new window.SVGPathSegCurvetoCubicSmoothRel(undefined, x, y, x2, y2); }
         window.SVGPathElement.prototype.createSVGPathSegCurvetoQuadraticSmoothAbs = function(x, y) { return new window.SVGPathSegCurvetoQuadraticSmoothAbs(undefined, x, y); }
         window.SVGPathElement.prototype.createSVGPathSegCurvetoQuadraticSmoothRel = function(x, y) { return new window.SVGPathSegCurvetoQuadraticSmoothRel(undefined, x, y); }
+
+        if (!("getPathSegAtLength" in window.SVGPathElement.prototype)) {
+            // Add getPathSegAtLength to SVGPathElement.
+            // Spec: https://www.w3.org/TR/SVG11/single-page.html#paths-__svg__SVGPathElement__getPathSegAtLength
+            window.SVGPathElement.prototype.getPathSegAtLength = function(distance) {
+                if (distance === undefined || !isFinite(distance))
+                    throw "Invalid arguments.";
+
+                var measurementElement = document.createElementNS("http://www.w3.org/2000/svg", "path");
+                measurementElement.setAttribute("d", this.getAttribute("d"));
+                var lastPathSegment = measurementElement.pathSegList.numberOfItems - 1;
+
+                // If the path is empty, return 0.
+                if (lastPathSegment <= 0)
+                    return 0;
+
+                do {
+                    measurementElement.pathSegList.removeItem(lastPathSegment);
+                    if (distance > measurementElement.getTotalLength())
+                        break;
+                    lastPathSegment--;
+                } while (lastPathSegment > 0);
+                return lastPathSegment;
+            }
+        }
     }
 
     if (!("SVGPathSegList" in window)) {

--- a/pathseg.js
+++ b/pathseg.js
@@ -336,6 +336,7 @@
         if (!("getPathSegAtLength" in window.SVGPathElement.prototype)) {
             // Add getPathSegAtLength to SVGPathElement.
             // Spec: https://www.w3.org/TR/SVG11/single-page.html#paths-__svg__SVGPathElement__getPathSegAtLength
+            // This polyfill requires SVGPathElement.getTotalLength to implement the distance-along-a-path algorithm.
             window.SVGPathElement.prototype.getPathSegAtLength = function(distance) {
                 if (distance === undefined || !isFinite(distance))
                     throw "Invalid arguments.";

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -785,3 +785,98 @@ QUnit.test("Asynchronous mutation observer", function(assert) {
         done();
     });
 });
+
+QUnit.test("Test getPathSegAtLength length boundary conditions", function(assert) {
+    var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+
+    // Empty path.
+    path.setAttribute("d", "");
+    assert.equal(path.getPathSegAtLength(-10), "0");
+    assert.equal(path.getPathSegAtLength(0), "0");
+    assert.equal(path.getPathSegAtLength(1), "0");
+    assert.equal(path.getPathSegAtLength(10), "0");
+
+    // Path with one segment.
+    path.setAttribute("d", "M1 1");
+    assert.equal(path.getPathSegAtLength(-10), "0");
+    assert.equal(path.getPathSegAtLength(0), "0");
+    assert.equal(path.getPathSegAtLength(1), "0");
+    assert.equal(path.getPathSegAtLength(10), "0");
+
+    // Path with one close segment.
+    path.setAttribute("d", "z");
+    assert.equal(path.getPathSegAtLength(-10), "0");
+    assert.equal(path.getPathSegAtLength(0), "0");
+    assert.equal(path.getPathSegAtLength(1), "0");
+    assert.equal(path.getPathSegAtLength(10), "0");
+});
+
+// LayoutTests/svg/dom/script-tests/svgpath-getPathSegAtLength.js
+QUnit.test("Test the getPathSegAtLength API", function(assert) {
+    var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "M0 0 L0 5 L5 5 L 5 0");
+
+    assert.equal(path.getPathSegAtLength(0), "0");
+    assert.equal(path.getPathSegAtLength(1), "1");
+    assert.equal(path.getPathSegAtLength(5), "1");
+    assert.equal(path.getPathSegAtLength(6), "2");
+    assert.equal(path.getPathSegAtLength(10), "2");
+    assert.equal(path.getPathSegAtLength(11), "3");
+    // WebKit/Opera/FF all return the last path segment if the distance exceeds the actual path length:
+    assert.equal(path.getPathSegAtLength(16), "3");
+    assert.equal(path.getPathSegAtLength(20), "3");
+    assert.equal(path.getPathSegAtLength(24), "3");
+    assert.equal(path.getPathSegAtLength(25), "3");
+    assert.equal(path.getPathSegAtLength(100), "3");
+});
+
+// LayoutTests/svg/dom/SVGGeometryElement-valid-arguments.html
+QUnit.test("Test invalid arguments when calling getPathSegAtLength", function(assert) {
+    var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    assert.throws(function() {
+        path.getPathSegAtLength();
+    });
+    assert.throws(function() {
+        path.getPathSegAtLength(NaN);
+    });
+    assert.throws(function() {
+        path.getPathSegAtLength(Infinity);
+    });
+});
+
+QUnit.test("Test getPathSegAtLength with non-trivial paths", function(assert) {
+    var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+
+    // Absolute line-to.
+    path.setAttribute("d", "M0 0 L0 5 L5 5 L5 0");
+    assert.equal(path.getPathSegAtLength(0), "0");
+    assert.equal(path.getPathSegAtLength(1), "1");
+    assert.equal(path.getPathSegAtLength(5), "1");
+    assert.equal(path.getPathSegAtLength(6), "2");
+
+    // Relative line-to.
+    path.setAttribute("d", "M0 0 l0 5 l5 0 l0 -5");
+    assert.equal(path.getPathSegAtLength(0), "0");
+    assert.equal(path.getPathSegAtLength(1), "1");
+    assert.equal(path.getPathSegAtLength(5), "1");
+    assert.equal(path.getPathSegAtLength(6), "2");
+
+    // Cubic curve.
+    path.setAttribute("d", "M100,250 C 100,50 400,50 400,250Z");
+    assert.equal(path.getPathSegAtLength(0), "0");
+    assert.equal(path.getPathSegAtLength(1), "1");
+    assert.equal(path.getPathSegAtLength(100), "1");
+    assert.equal(path.getPathSegAtLength(200), "1");
+    assert.equal(path.getPathSegAtLength(300), "1");
+    assert.equal(path.getPathSegAtLength(400), "1");
+    assert.equal(path.getPathSegAtLength(500), "2");
+
+    // Multiple quadratic curves.
+    path.setAttribute("d", "M0,0 Q0,0 100,50 T100,100 T300, 300Z");
+    assert.equal(path.getPathSegAtLength(0), "0");
+    assert.equal(path.getPathSegAtLength(1), "1");
+    assert.equal(path.getPathSegAtLength(100), "1");
+    assert.equal(path.getPathSegAtLength(200), "2");
+    assert.equal(path.getPathSegAtLength(400), "3");
+    assert.equal(path.getPathSegAtLength(600), "4");
+});

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -879,4 +879,15 @@ QUnit.test("Test getPathSegAtLength with non-trivial paths", function(assert) {
     assert.equal(path.getPathSegAtLength(200), "2");
     assert.equal(path.getPathSegAtLength(400), "3");
     assert.equal(path.getPathSegAtLength(600), "4");
+
+    // Discontinuous paths.
+    // This didn't get spec'd (see: https://github.com/w3c/svgwg/issues/282) but had consistent behavior in Edge, Blink, WebKit, and Gecko.
+    path.setAttribute("d", "M0,0 h100 M100,100 v0 M0,100 h0");
+    assert.equal(path.getPathSegAtLength(99), "1");
+    assert.equal(path.getPathSegAtLength(100), "1");
+    assert.equal(path.getPathSegAtLength(101), "5");
+    path.setAttribute("d", "M50,50 L150,50 M50,100 L150,100");
+    assert.equal(path.getPathSegAtLength(99), "1");
+    assert.equal(path.getPathSegAtLength(100), "1");
+    assert.equal(path.getPathSegAtLength(101), "3");
 });


### PR DESCRIPTION
This is a polyfill implementation of getPathSegAtLength which may be removed from blink:
https://groups.google.com/a/chromium.org/d/msg/blink-dev/Gc1Aw282beo/NsfsKf8LBgAJ

Original spec:
https://www.w3.org/TR/SVG11/paths.html#__svg__SVGPathElement__getPathSegAtLength

This implementation uses a test path element and getTotalLength(). Path segments are popped off the end of the test path until the length goes below the queried distance.

This fixes #17 