### PR TITLE
Add support for Firefox 59+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Now used by [svg-edit](https://github.com/SVG-Edit/svgedit) and passes all svg-e
 
 Blink will likely remove SVGPathElement.getPathSegAtLength (see: [Intent to deprecate and remove SVGPathElement.getPathSegAtLength](https://groups.google.com/a/chromium.org/d/msg/blink-dev/Gc1Aw282beo/NsfsKf8LBgAJ)). A getPathSegAtLength polyfill has been added to this library.
 
+Firefox 59 will likely remove portions of the SVGPathSeg and SVGPathSegList APIs (see: [Remove the WebIDL methods for creating and mutating SVG path data](https://bugzilla.mozilla.org/show_bug.cgi?id=1436438)). This library has support for polyfilling this partial implementation.
+
 ## Using pathseg.js
 Just add pathseg.js to your server and drop this in your html or svg files:
 ```

--- a/pathseg.js
+++ b/pathseg.js
@@ -360,7 +360,12 @@
         }
     }
 
-    if (!("SVGPathSegList" in window)) {
+    // Checking for SVGPathSegList in window checks for the case of an implementation without the
+    // SVGPathSegList API.
+    // The second check for appendItem is specific to Firefox 59+ which removed only parts of the
+    // SVGPathSegList API (e.g., appendItem). In this case we need to re-implement the entire API
+    // so the polyfill data (i.e., _list) is used throughout.
+    if (!("SVGPathSegList" in window) || !("appendItem" in window.SVGPathSegList.prototype)) {
         // Spec: http://www.w3.org/TR/SVG11/single-page.html#paths-InterfaceSVGPathSegList
         window.SVGPathSegList = function(pathElement) {
             this._pathElement = pathElement;


### PR DESCRIPTION
Firefox 59+ will remove support for some of the SVGPathSeg APIs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1436438
(specifically, https://hg.mozilla.org/releases/mozilla-beta/rev/a9062e1bafb7)

This patch updates the polyfill to work in Firefox 59+. With this patch, all tests now pass. I also tested svgedit with the updated polyfill and ensured path editing works.

This fixes issue #23 