### PR TITLE
add length property to window.SVGPathSegList

### DIFF
--- a/pathseg.js
+++ b/pathseg.js
@@ -387,7 +387,7 @@
             enumerable: true
         });
 
-        //length property is built in Firefox 58-
+        // The length property was not specified but was in Firefox 58.
         Object.defineProperty(window.SVGPathSegList.prototype, "length", {
             get: function() {
                 this._checkPathSynchronizedToList();

--- a/pathseg.js
+++ b/pathseg.js
@@ -387,6 +387,15 @@
             enumerable: true
         });
 
+        //length property is built in Firefox 58-
+        Object.defineProperty(window.SVGPathSegList.prototype, "length", {
+            get: function() {
+                this._checkPathSynchronizedToList();
+                return this._list.length;
+            },
+            enumerable: true
+        });
+
         // Add the pathSegList accessors to window.SVGPathElement.
         // Spec: http://www.w3.org/TR/SVG11/single-page.html#paths-InterfaceSVGAnimatedPathData
         Object.defineProperty(window.SVGPathElement.prototype, "pathSegList", {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -891,3 +891,27 @@ QUnit.test("Test getPathSegAtLength with non-trivial paths", function(assert) {
     assert.equal(path.getPathSegAtLength(100), "1");
     assert.equal(path.getPathSegAtLength(101), "3");
 });
+
+QUnit.test("Test PathSegList.length", function(assert) {
+	var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+
+	// Empty path.
+	path.setAttribute("d", "");
+	assert.equal(path.pathSegList.length, path.pathSegList.numberOfItems);
+	assert.equal(path.pathSegList.length, 0);
+
+	// Path with one segment.
+	path.setAttribute("d", "M1 1");
+	assert.equal(path.pathSegList.length, path.pathSegList.numberOfItems);
+	assert.equal(path.pathSegList.length, 1);
+
+	// Path with one close segment.
+	path.setAttribute("d", "z");
+	assert.equal(path.pathSegList.length, path.pathSegList.numberOfItems);
+	assert.equal(path.pathSegList.length, 0);
+
+	// Path with two segments and a close.
+	path.setAttribute("d", "M1 1 L2 2Z");
+	assert.equal(path.pathSegList.length, path.pathSegList.numberOfItems);
+	assert.equal(path.pathSegList.length, 3);
+});


### PR DESCRIPTION
Its built in Firefox 58- implements NOT in W3C specification.

commented on https://bugzilla.mozilla.org/show_bug.cgi?id=1441233 .